### PR TITLE
Attackers method in Board

### DIFF
--- a/docs/pages/board-object.md
+++ b/docs/pages/board-object.md
@@ -31,6 +31,13 @@ class Board {
 
         Bitboard pieces(PieceType type);
 
+        /// @brief Returns a bitboard wiht the origin squares of the attacking pieces set
+        /// @param color Attacker Color
+        /// @param square Attacked Square
+        /// @param occupied 
+        /// @return 
+        Bitboard attackers(Color color, Square square, Bitboard occupied);
+
         /// @brief Checks if a move is a capture, enpassant moves are also considered captures.
         /// @param move
         /// @return

--- a/src/chess.hpp
+++ b/src/chess.hpp
@@ -1196,14 +1196,12 @@ class Board {
     /// @return 
     [[nodiscard]] Bitboard attackers(Color color, Square square, Bitboard occupied) {
         const auto queens = pieces(PieceType::QUEEN, color);
-        const auto bishops = pieces(PieceType::BISHOP, color);
-        const auto rooks = pieces(PieceType::ROOK, color);
 
         // using the fact that if we can attack PieceType from square, they can attack us back
         auto atks = (movegen::attacks::pawn(~color, square) & pieces(PieceType::PAWN, color));
         atks |= (movegen::attacks::knight(square) & pieces(PieceType::KNIGHT, color));
-        atks |= (movegen::attacks::bishop(square, occupied) & (bishops | queens));
-        atks |= (movegen::attacks::rook(square, occupied) & (rooks | queens));
+        atks |= (movegen::attacks::bishop(square, occupied) & (pieces(PieceType::BISHOP, color) | queens));
+        atks |= (movegen::attacks::rook(square, occupied) & (pieces(PieceType::ROOK, color) | queens));
         atks |= (movegen::attacks::king(square) & pieces(PieceType::KING, color));
 
         return atks & occupied;

--- a/src/chess.hpp
+++ b/src/chess.hpp
@@ -1189,9 +1189,9 @@ class Board {
         return pieces(type, Color::WHITE) | pieces(type, Color::BLACK);
     }
 
-    /// @brief Returns all attackers of a certain color on a certain square
-    /// @param color 
-    /// @param square 
+    /// @brief Returns a bitboard wiht the origin squares of the attacking pieces set
+    /// @param color Attacker Color
+    /// @param square Attacked Square
     /// @param occupied 
     /// @return 
     [[nodiscard]] Bitboard attackers(Color color, Square square, Bitboard occupied) {

--- a/src/chess.hpp
+++ b/src/chess.hpp
@@ -1605,7 +1605,7 @@ inline std::pair<GameResultReason, GameResult> Board::isGameOver() const {
         Movelist movelist;
         movegen::legalmoves<MoveGenType::ALL>(movelist, board);
 
-        if (movelist.empty() && isAttacked(kingSq(side_to_move_), ~side_to_move_)) {
+        if (movelist.empty() && inCheck()) {
             return {GameResultReason::CHECKMATE, GameResult::LOSE};
         }
 
@@ -1623,7 +1623,7 @@ inline std::pair<GameResultReason, GameResult> Board::isGameOver() const {
     movegen::legalmoves<MoveGenType::ALL>(movelist, board);
 
     if (movelist.empty()) {
-        if (isAttacked(kingSq(side_to_move_), ~side_to_move_))
+        if (inCheck())
             return {GameResultReason::CHECKMATE, GameResult::LOSE};
         return {GameResultReason::STALEMATE, GameResult::DRAW};
     }

--- a/src/chess.hpp
+++ b/src/chess.hpp
@@ -1206,7 +1206,7 @@ class Board {
         atks |= (movegen::attacks::rook(square, occupied) & (rooks | queens));
         atks |= (movegen::attacks::king(square) & pieces(PieceType::KING, color));
 
-        return atks;
+        return atks & occupied;
     }
 
     /// @brief Returns either the piece or the piece type on a square

--- a/src/chess.hpp
+++ b/src/chess.hpp
@@ -1189,6 +1189,26 @@ class Board {
         return pieces(type, Color::WHITE) | pieces(type, Color::BLACK);
     }
 
+    /// @brief Returns all attackers of a certain color on a certain square
+    /// @param color 
+    /// @param square 
+    /// @param occupied 
+    /// @return 
+    [[nodiscard]] Bitboard attackers(Color color, Square square, Bitboard occupied) {
+        const auto queens = pieces(PieceType::QUEEN, color);
+        const auto bishops = pieces(PieceType::BISHOP, color);
+        const auto rooks = pieces(PieceType::ROOK, color);
+
+        // using the fact that if we can attack PieceType from square, they can attack us back
+        auto atks = (movegen::attacks::pawn(~color, square) & pieces(PieceType::PAWN, color));
+        atks |= (movegen::attacks::knight(square) & pieces(PieceType::KNIGHT, color));
+        atks |= (movegen::attacks::bishop(square, occupied) & (bishops | queens));
+        atks |= (movegen::attacks::rook(square, occupied) & (rooks | queens));
+        atks |= (movegen::attacks::king(square) & pieces(PieceType::KING, color));
+
+        return atks;
+    }
+
     /// @brief Returns either the piece or the piece type on a square
     /// @tparam T
     /// @param sq


### PR DESCRIPTION
Hi, this is my first commit on a public repo so I apologize in advance if I made a terrible mistake somewhere (either in my code or in this general process).

Anyways, I made two main changes. 

One is that I added a `attackers()` method inside of the `Board` class to get a bitboard for every piece of a certain color attacking a certain square. I added `occupancy` as a parameter to help find xray attackers, which is mostly useful for implementing [Static Exchange Evaluations](https://www.chessprogramming.org/Static_Exchange_Evaluation#Implementation) in engines (hence why I made this PR). You can basically modify the occupancy you input to virtually remove certain pieces, such as the first rook in a double rook battery, allowing you to find more attackers without having to play out any move.

The other change is a very minor one; I just replaced the `isAttacked` code inside game end detection with `inCheck` for readability (and less repetition, I guess). 