### PR TITLE
fix two PGN parsing bugs

### DIFF
--- a/include/chess.hpp
+++ b/include/chess.hpp
@@ -25,7 +25,7 @@ Source: https://github.com/Disservin/chess-library
 */
 
 /*
-VERSION: 0.4.5
+VERSION: 0.4.6
 */
 
 #ifndef CHESS_HPP

--- a/include/chess.hpp
+++ b/include/chess.hpp
@@ -3569,7 +3569,7 @@ class StreamParser {
                     reading_comment = false;
 
                     if (!move.empty()) {
-                        if (move[0] == '-') {
+                        if (move[0] == '-' && move.size() > 1) {
                             move = move[1] + move;
                         }
                         if (!visitor->skip()) visitor->move(move, comment);
@@ -3585,7 +3585,7 @@ class StreamParser {
                     }
 
                     if (!move.empty()) {
-                        if (move[0] == '-') {
+                        if (move[0] == '-' && move.size() > 1) {
                             move = move[1] + move;
                         }
                         if (!visitor->skip()) visitor->move(move, comment);


### PR DESCRIPTION
One bug was discovered by @vondele and relates to `'\n'` not finishing the reading of a move.

The other bug relates to `0-0` not always being recognized as a castling move, because `0` is not a letter. I fixed this with a bit of a hack: we now check also for `-` to start a move, and then retrospectively add the missing first character to the move before we send it back.

Some testing would be good.