### PR TITLE
correct pgn parsing

### DIFF
--- a/include/chess.hpp
+++ b/include/chess.hpp
@@ -3393,6 +3393,7 @@ class StreamParser {
 
         move.reserve(16);
         comment.reserve(256);
+        cbuf = "   ";
     }
 
     void readGames(Visitor &vis) {
@@ -3478,6 +3479,11 @@ class StreamParser {
                            std::streamsize &buffer_index, bool &has_head, bool &has_body) {
         for (std::streamsize i = buffer_index; i < length; ++i) {
             char c = buffer[i];
+
+            // save the last three characters across different buffers
+            cbuf[2] = cbuf[1];
+            cbuf[1] = cbuf[0];
+            cbuf[0] = c;
 
             // skip carriage return
             if (c == '\r') {
@@ -3584,7 +3590,7 @@ class StreamParser {
                 else if (!reading_move && !reading_comment) {
                     // O-O(-O) castling moves are caught by isLetter(c), and we need to distinguish
                     // 0-0(-0) castling moves from results like 1-0 and 0-1.
-                    if (isLetter(c) || (c == '0' && i > 1 && buffer[i-1] == '-' && buffer[i-2] == '0')) {
+                    if (isLetter(c) || (c == '0' && cbuf[1] == '-' && cbuf[2] == '0')) {
                         callMove();
                         reading_move = true;
                         if (c == '0') {
@@ -3623,6 +3629,7 @@ class StreamParser {
 
     std::string move;
     std::string comment;
+    std::string cbuf;
 
     // State
 

--- a/tests/pgn.cpp
+++ b/tests/pgn.cpp
@@ -47,7 +47,7 @@ TEST_SUITE("PGN StreamParser") {
         pgn::StreamParser parser(file_stream);
         parser.readGames(*vis);
 
-        // CHECK(vis->count() == 130); @TODO fix 1/2-1/2 being interpreted as a move
+        CHECK(vis->count() == 130);
         CHECK(vis->gameCount() == 1);
         CHECK(vis->endCount() == 1);
         CHECK(vis->moveStartCount() == 1);
@@ -61,7 +61,7 @@ TEST_SUITE("PGN StreamParser") {
         pgn::StreamParser parser(file_stream);
         parser.readGames(*vis);
 
-        // CHECK(vis->count() == 124); @TODO fix 1/2-1/2 being interpreted as a move
+        CHECK(vis->count() == 125);
         CHECK(vis->gameCount() == 1);
         CHECK(vis->endCount() == 1);
         CHECK(vis->moveStartCount() == 1);
@@ -104,7 +104,7 @@ TEST_SUITE("PGN StreamParser") {
         CHECK(vis->gameCount() == 2);
         CHECK(vis->endCount() == 2);
         CHECK(vis->moveStartCount() == 1);
-        // CHECK(vis->count() == 130); @TODO fix 1/2-1/2 being interpreted as a move
+        CHECK(vis->count() == 130);
     }
 
     TEST_CASE("Newline by moves") {
@@ -122,7 +122,7 @@ TEST_SUITE("PGN StreamParser") {
     }
 
     TEST_CASE("Castling with 0-0") {
-        const auto file  = "./pgns/castling .pgn";
+        const auto file  = "./pgns/castling.pgn";
         auto file_stream = std::ifstream(file);
 
         auto vis = std::make_unique<MyVisitor>();
@@ -133,5 +133,19 @@ TEST_SUITE("PGN StreamParser") {
         CHECK(vis->endCount() == 1);
         CHECK(vis->moveStartCount() == 1);
         CHECK(vis->count() == 6);
+    }
+
+    TEST_CASE("Black to move, and castling with 0-0-0") {
+        const auto file  = "./pgns/black2move.pgn";
+        auto file_stream = std::ifstream(file);
+
+        auto vis = std::make_unique<MyVisitor>();
+        pgn::StreamParser parser(file_stream);
+        parser.readGames(*vis);
+
+        CHECK(vis->gameCount() == 1);
+        CHECK(vis->endCount() == 1);
+        CHECK(vis->moveStartCount() == 1);
+        CHECK(vis->count() == 3);
     }
 }

--- a/tests/pgns/black2move.pgn
+++ b/tests/pgns/black2move.pgn
@@ -1,0 +1,4 @@
+[Event "*"]
+[FEN "r2qk2r/1bpp2pp/n3pn2/p2P1p2/1bP5/2N1BNP1/1PQ1PPBP/R3K2R b KQkq - 0 1"]
+
+1...0-0-0 2. 0-0 Nc5


### PR DESCRIPTION
This should fix all the parsing issues.

I am not 100% if the `buffer[i-2]` access is always well-defined, even across chunks. So a thorough review is warranted I think.

I bumped the version to 0.5.0, hope that is fine.

Also added a pgn test with black to move first, and with `0-0-0` in it.

Now `./out -ts="PGN StreamParser"` works without problems.