### PR TITLE
fix constexpr for visualstudio compiler

### DIFF
--- a/include/chess.hpp
+++ b/include/chess.hpp
@@ -131,7 +131,7 @@ class File {
     constexpr File() : file(underlying::NO_FILE) {}
     constexpr File(underlying file) : file(file) {}
     constexpr File(int file) : file(static_cast<underlying>(file)) {}
-    constexpr File(std::string_view sw)
+    File(std::string_view sw)
         : file(static_cast<underlying>(static_cast<char>(std::tolower(static_cast<unsigned char>(sw[0]))) - 'a')) {}
 
     [[nodiscard]] constexpr underlying internal() const noexcept { return file; }
@@ -181,7 +181,7 @@ class Rank {
     constexpr Rank() : rank(underlying::NO_RANK) {}
     constexpr Rank(underlying rank) : rank(rank) {}
     constexpr Rank(int rank) : rank(static_cast<underlying>(rank)) {}
-    constexpr Rank(std::string_view sw)
+    Rank(std::string_view sw)
         : rank(static_cast<underlying>(static_cast<char>(std::tolower(static_cast<unsigned char>(sw[0]))) - '1')) {}
 
     [[nodiscard]] constexpr underlying internal() const noexcept { return rank; }


### PR DESCRIPTION
I couldn't explore this deeply, but it fix the constexpr problem on VS2022. Strangelly clang and GCC doesn't needs this fix.