### PR TITLE
Fix type error in iterators

### DIFF
--- a/include/chess.hpp
+++ b/include/chess.hpp
@@ -25,7 +25,7 @@ THIS FILE IS AUTO GENERATED DO NOT CHANGE MANUALLY.
 
 Source: https://github.com/Disservin/chess-library
 
-VERSION: 0.6.37
+VERSION: 0.6.38
 */
 
 #ifndef CHESS_HPP
@@ -1265,24 +1265,11 @@ class Movelist {
 
     // Iterators
 
-    [[nodiscard]] constexpr iterator begin() noexcept { return moves_.begin(); }
-    [[nodiscard]] constexpr const_iterator begin() const noexcept { return moves_.begin(); }
+    [[nodiscard]] constexpr iterator begin() noexcept { return &moves_[0]; }
+    [[nodiscard]] constexpr const_iterator begin() const noexcept { return &moves_[0]; }
 
-    [[nodiscard]] constexpr auto end() noexcept { return moves_.begin() + size_; }
-    [[nodiscard]] constexpr const_iterator end() const noexcept { return moves_.begin() + size_; }
-
-    [[nodiscard]] constexpr reverse_iterator rbegin() noexcept {
-        return moves_.rbegin() + (constants::MAX_MOVES - size_);
-    }
-
-    [[nodiscard]] constexpr const_reverse_iterator rbegin() const noexcept {
-        return moves_.rbegin() + (constants::MAX_MOVES - size_);
-    }
-
-    [[nodiscard]] constexpr reverse_iterator rend() noexcept { return moves_.rbegin() + constants::MAX_MOVES; }
-    [[nodiscard]] constexpr const_reverse_iterator rend() const noexcept {
-        return moves_.rbegin() + constants::MAX_MOVES;
-    }
+    [[nodiscard]] constexpr iterator end() noexcept { return &moves_[0] + size_; }
+    [[nodiscard]] constexpr const_iterator end() const noexcept { return &moves_[0] + size_; }
 
     // Capacity
 

--- a/src/include.hpp
+++ b/src/include.hpp
@@ -25,7 +25,7 @@ THIS FILE IS AUTO GENERATED DO NOT CHANGE MANUALLY.
 
 Source: https://github.com/Disservin/chess-library
 
-VERSION: 0.6.37
+VERSION: 0.6.38
 */
 
 #ifndef CHESS_HPP

--- a/src/movelist.hpp
+++ b/src/movelist.hpp
@@ -56,24 +56,11 @@ class Movelist {
 
     // Iterators
 
-    [[nodiscard]] constexpr auto begin() noexcept { return moves_.begin(); }
-    [[nodiscard]] constexpr auto begin() const noexcept { return moves_.begin(); }
+    [[nodiscard]] constexpr iterator begin() noexcept { return &moves_[0]; }
+    [[nodiscard]] constexpr const_iterator begin() const noexcept { return &moves_[0]; }
 
-    [[nodiscard]] constexpr auto end() noexcept { return moves_.begin() + size_; }
-    [[nodiscard]] constexpr auto end() const noexcept { return moves_.begin() + size_; }
-
-    [[nodiscard]] constexpr auto rbegin() noexcept {
-        return moves_.rbegin() + (constants::MAX_MOVES - size_);
-    }
-
-    [[nodiscard]] constexpr auto rbegin() const noexcept {
-        return moves_.rbegin() + (constants::MAX_MOVES - size_);
-    }
-
-    [[nodiscard]] constexpr auto rend() noexcept { return moves_.rbegin() + constants::MAX_MOVES; }
-    [[nodiscard]] constexpr auto rend() const noexcept {
-        return moves_.rbegin() + constants::MAX_MOVES;
-    }
+    [[nodiscard]] constexpr iterator end() noexcept { return &moves_[0] + size_; }
+    [[nodiscard]] constexpr const_iterator end() const noexcept { return &moves_[0] + size_; }
 
     // Capacity
 

--- a/src/movelist.hpp
+++ b/src/movelist.hpp
@@ -56,22 +56,22 @@ class Movelist {
 
     // Iterators
 
-    [[nodiscard]] constexpr iterator begin() noexcept { return moves_.begin(); }
-    [[nodiscard]] constexpr const_iterator begin() const noexcept { return moves_.begin(); }
+    [[nodiscard]] constexpr auto begin() noexcept { return moves_.begin(); }
+    [[nodiscard]] constexpr auto begin() const noexcept { return moves_.begin(); }
 
     [[nodiscard]] constexpr auto end() noexcept { return moves_.begin() + size_; }
-    [[nodiscard]] constexpr const_iterator end() const noexcept { return moves_.begin() + size_; }
+    [[nodiscard]] constexpr auto end() const noexcept { return moves_.begin() + size_; }
 
-    [[nodiscard]] constexpr reverse_iterator rbegin() noexcept {
+    [[nodiscard]] constexpr auto rbegin() noexcept {
         return moves_.rbegin() + (constants::MAX_MOVES - size_);
     }
 
-    [[nodiscard]] constexpr const_reverse_iterator rbegin() const noexcept {
+    [[nodiscard]] constexpr auto rbegin() const noexcept {
         return moves_.rbegin() + (constants::MAX_MOVES - size_);
     }
 
-    [[nodiscard]] constexpr reverse_iterator rend() noexcept { return moves_.rbegin() + constants::MAX_MOVES; }
-    [[nodiscard]] constexpr const_reverse_iterator rend() const noexcept {
+    [[nodiscard]] constexpr auto rend() noexcept { return moves_.rbegin() + constants::MAX_MOVES; }
+    [[nodiscard]] constexpr auto rend() const noexcept {
         return moves_.rbegin() + constants::MAX_MOVES;
     }
 


### PR DESCRIPTION
After building the library and adding the necessary `#include` statement, the project's build command fails due to a type mismatch:
```
  [1/2] Building CXX object CMakeFiles\cpp.dir\src\a.cpp.obj
  FAILED: CMakeFiles/a-cpp.dir/src/a.cpp.obj 
  C:\PROGRA~1\MICROS~3\2022\COMMUN~1\VC\Tools\MSVC\1439~1.335\bin\Hostx64\x64\cl.exe  /nologo /TP  -IC:\Users\a\source\repos\a-cpp\external /DWIN32 /D_WINDOWS /W3 /GR /EHsc /MDd /Ob0 /Od /RTC1 -std:c++20 -ZI /showIncludes /FoCMakeFiles\a-cpp.dir\src\a.cpp.obj /FdCMakeFiles\a-cpp.dir\ /FS -c C:\Users\a\source\repos\a-cpp\src\a.cpp
C:\Users\a\source\repos\a-cpp\external\chess.hpp(1268): error C2440: 'return': cannot convert from 'std::_Array_iterator<_Ty,256>' to 'chess::Movelist::iterator'
          with
          [
              _Ty=chess::Movelist::value_type
          ]
  C:\Users\a\source\repos\a-cpp\external\chess.hpp(1268): note: No user-defined-conversion operator available that can perform this conversion, or the operator cannot be called
C:\Users\a\source\repos\a-cpp\external\chess.hpp(1268): error C3615: constexpr function 'chess::Movelist::begin' cannot result in a constant expression
  C:\Users\a\source\repos\a-cpp\external\chess.hpp(1268): note: failure was caused by control reaching the end of a constexpr function
C:\Users\a\source\repos\a-cpp\external\chess.hpp(1269): error C2440: 'return': cannot convert from 'std::_Array_const_iterator<_Ty,256>' to 'chess::Movelist::const_iterator'
          with
          [
              _Ty=chess::Movelist::value_type
          ]
  C:\Users\a\source\repos\a-cpp\external\chess.hpp(1269): note: No user-defined-conversion operator available that can perform this conversion, or the operator cannot be called
C:\Users\a\source\repos\a-cpp\external\chess.hpp(1269): error C3615: constexpr function 'chess::Movelist::begin' cannot result in a constant expression
  C:\Users\a\source\repos\a-cpp\external\chess.hpp(1269): note: failure was caused by control reaching the end of a constexpr function
C:\Users\a\source\repos\a-cpp\external\chess.hpp(1272): error C2440: 'return': cannot convert from 'std::_Array_const_iterator<_Ty,256>' to 'chess::Movelist::const_iterator'
          with
          [
              _Ty=chess::Movelist::value_type
          ]
  C:\Users\a\source\repos\a-cpp\external\chess.hpp(1272): note: No user-defined-conversion operator available that can perform this conversion, or the operator cannot be called
C:\Users\a\source\repos\a-cpp\external\chess.hpp(1272): error C3615: constexpr function 'chess::Movelist::end' cannot result in a constant expression
  C:\Users\a\source\repos\a-cpp\external\chess.hpp(1272): note: failure was caused by control reaching the end of a constexpr function
C:\Users\a\source\repos\a-cpp\external\chess.hpp(1275): error C2440: 'return': cannot convert from 'std::reverse_iterator<std::_Array_iterator<_Ty,256>>' to 'std::reverse_iterator<chess::Movelist::iterator>'
          with
          [
              _Ty=chess::Movelist::value_type
          ]
  C:\Users\a\source\repos\a-cpp\external\chess.hpp(1275): note: No user-defined-conversion operator available that can perform this conversion, or the operator cannot be called
C:\Users\a\source\repos\a-cpp\external\chess.hpp(1279): error C2440: 'return': cannot convert from 'std::reverse_iterator<std::_Array_const_iterator<_Ty,256>>' to 'std::reverse_iterator<chess::Movelist::const_iterator>'
          with
          [
              _Ty=chess::Movelist::value_type
          ]
  C:\Users\a\source\repos\a-cpp\external\chess.hpp(1279): note: No user-defined-conversion operator available that can perform this conversion, or the operator cannot be called
C:\Users\a\source\repos\a-cpp\external\chess.hpp(1282): error C2440: 'return': cannot convert from 'std::reverse_iterator<std::_Array_iterator<_Ty,256>>' to 'std::reverse_iterator<chess::Movelist::iterator>'
          with
          [
              _Ty=chess::Movelist::value_type
          ]
  C:\Users\a\source\repos\a-cpp\external\chess.hpp(1282): note: No user-defined-conversion operator available that can perform this conversion, or the operator cannot be called
C:\Users\a\source\repos\a-cpp\external\chess.hpp(1284): error C2440: 'return': cannot convert from 'std::reverse_iterator<std::_Array_const_iterator<_Ty,256>>' to 'std::reverse_iterator<chess::Movelist::const_iterator>'
          with
          [
              _Ty=chess::Movelist::value_type
          ]
  C:\Users\a\source\repos\a-cpp\external\chess.hpp(1284): note: No user-defined-conversion operator available that can perform this conversion, or the operator cannot be called
  ninja: build stopped: subcommand failed.

Build All failed.
```