### PR TITLE
fix: add same color bishop case to insufficient material check

### DIFF
--- a/include/chess.hpp
+++ b/include/chess.hpp
@@ -25,7 +25,7 @@ THIS FILE IS AUTO GENERATED DO NOT CHANGE MANUALLY.
 
 Source: https://github.com/Disservin/chess-library
 
-VERSION: 0.6.54
+VERSION: 0.6.55
 */
 
 #ifndef CHESS_HPP
@@ -2284,6 +2284,16 @@ class Board {
                 Square::same_color(pieces(PieceType::BISHOP, Color::WHITE).lsb(),
                                    pieces(PieceType::BISHOP, Color::BLACK).lsb()))
                 return true;
+
+            // one side with two bishops which have the same color
+            auto white_bishops = pieces(PieceType::BISHOP, Color::WHITE);
+            auto black_bishops = pieces(PieceType::BISHOP, Color::BLACK);
+
+            if (white_bishops.count() == 2) {
+                if (Square::same_color(white_bishops.lsb(), white_bishops.msb())) return true;
+            } else if (black_bishops.count() == 2) {
+                if (Square::same_color(black_bishops.lsb(), black_bishops.msb())) return true;
+            }
         }
 
         return false;

--- a/src/board.hpp
+++ b/src/board.hpp
@@ -660,6 +660,16 @@ class Board {
                 Square::same_color(pieces(PieceType::BISHOP, Color::WHITE).lsb(),
                                    pieces(PieceType::BISHOP, Color::BLACK).lsb()))
                 return true;
+
+            // one side with two bishops which have the same color
+            auto white_bishops = pieces(PieceType::BISHOP, Color::WHITE);
+            auto black_bishops = pieces(PieceType::BISHOP, Color::BLACK);
+
+            if (white_bishops.count() == 2) {
+                if (Square::same_color(white_bishops.lsb(), white_bishops.msb())) return true;
+            } else if (black_bishops.count() == 2) {
+                if (Square::same_color(black_bishops.lsb(), black_bishops.msb())) return true;
+            }
         }
 
         return false;

--- a/src/include.hpp
+++ b/src/include.hpp
@@ -25,7 +25,7 @@ THIS FILE IS AUTO GENERATED DO NOT CHANGE MANUALLY.
 
 Source: https://github.com/Disservin/chess-library
 
-VERSION: 0.6.54
+VERSION: 0.6.55
 */
 
 #ifndef CHESS_HPP

--- a/tests/board.cpp
+++ b/tests/board.cpp
@@ -106,4 +106,39 @@ TEST_SUITE("Board") {
         CHECK(board.getFen() == "r1bqk1nr/1p1p1ppp/p1n1pb2/8/4P3/1N1B2Q1/PPP2PPP/RNB1K2R w KQkq - 8 9");
         CHECK(board.getEpd() == "r1bqk1nr/1p1p1ppp/p1n1pb2/8/4P3/1N1B2Q1/PPP2PPP/RNB1K2R w KQkq - hmvc 8; fmvn 9;");
     }
+
+    TEST_CASE("Insufficient Material Two White Light Bishops") {
+        Board board = Board("8/6k1/8/8/4B3/3B4/8/1K6 w - - 0 1");
+        CHECK(board.isInsufficientMaterial());
+    }
+
+    TEST_CASE("Insufficient Material Two Black Light Bishops") {
+        Board board = Board("8/6k1/8/8/4b3/3b4/K7/8 w - - 0 1");
+        CHECK(board.isInsufficientMaterial());
+    }
+
+    TEST_CASE("Insufficient Material White Bishop") {
+        Board board = Board("8/7k/8/8/3B4/8/8/1K6 w - - 0 1");
+        CHECK(board.isInsufficientMaterial());
+    }
+
+    TEST_CASE("Insufficient Material Black Bishop") {
+        Board board = Board("8/7k/8/8/3b4/8/8/1K6 w - - 0 1");
+        CHECK(board.isInsufficientMaterial());
+    }
+
+    TEST_CASE("Insufficient Material White Knight") {
+        Board board = Board("8/7k/8/8/3N4/8/8/1K6 w - - 0 1");
+        CHECK(board.isInsufficientMaterial());
+    }
+
+    TEST_CASE("Insufficient Material Black Knight") {
+        Board board = Board("8/7k/8/8/3n4/8/8/1K6 w - - 0 1");
+        CHECK(board.isInsufficientMaterial());
+    }
+
+    TEST_CASE("Insufficient Material White Light Bishop and White Dark Bishop") {
+        Board board = Board("8/7k/8/8/3BB3/8/8/1K6 w - - 0 1");
+        CHECK(board.isInsufficientMaterial() == false);
+    }
 }


### PR DESCRIPTION
a fen like "8/6k1/8/8/4B3/3B4/8/1K6 w - - 0 1" wasn't detected as being a position with insufficient mating material