### PR TITLE
fix: throw exception when closing pgn quote is missing

### DIFF
--- a/src/include.hpp
+++ b/src/include.hpp
@@ -25,7 +25,7 @@ THIS FILE IS AUTO GENERATED DO NOT CHANGE MANUALLY.
 
 Source: https://github.com/Disservin/chess-library
 
-VERSION: 0.6.71
+VERSION: 0.6.72
 */
 
 #ifndef CHESS_HPP

--- a/tests/pgn.cpp
+++ b/tests/pgn.cpp
@@ -590,7 +590,20 @@ TEST_SUITE("PGN StreamParser") {
 
         CHECK(vis->gameCount() == 2);
 
-            CHECK(vis->headers()[0] == "Event Batch 2690: probTTsv1 vs master");
+        CHECK(vis->headers()[0] == "Event Batch 2690: probTTsv1 vs master");
         CHECK(vis->headers()[7] == "Event Batch 269: probTTsv1 vs master");
+    }
+
+    TEST_CASE("Backslash In Header") {
+        const auto file  = "./tests/pgns/backslash_header.pgn";
+        auto file_stream = std::ifstream(file);
+
+        auto vis = std::make_unique<MyVisitor>();
+        pgn::StreamParser<1> parser(file_stream);
+
+        CHECK_THROWS_AS_MESSAGE(parser.readGames(*vis), pgn::StreamParserException,
+                                "Invalid PGN, missing closing quote in header");
+
+        CHECK(vis->gameCount() == 1);
     }
 }

--- a/tests/pgns/backslash_header.pgn
+++ b/tests/pgns/backslash_header.pgn
@@ -1,0 +1,19 @@
+[Event "Tournament \"]
+[Site "Madrid ESP"]
+[Date "2005.10.16"]
+[Round "6"]
+[White "Alvarez Abejon, Amilcar"]
+[Black "Martin Blanco, Fernando"]
+[Result "1-0"]
+[WhiteElo "2119"]
+[BlackElo "2105"]
+[ECO "D87g"]
+
+1.d4 Nf6 2.c4 g6 3.Nc3 d5 4.cxd5 Nxd5 5.e4 Nxc3 6.bxc3 Bg7 7.Bc4 c5 8.Ne2 
+O-O 9.O-O Nc6 10.Be3 Bd7 11.Rc1 a6 12.Qd2 b5 13.Bd3 Qa5 14.d5 c4 15.Bb1 
+Ne5 16.f4 Nd3 17.Bxd3 cxd3 18.Qxd3 Qxa2 19.Ra1 Qc4 20.Qxc4 bxc4 21.Rfb1 
+Bb5 22.Bd4 Rab8 23.Bxg7 Kxg7 24.Kf2 Rb6 25.Nd4 Rfb8 26.Ra5 Kf8 27.Ke3 Ke8 
+28.Nxb5 axb5 29.Kd4 R6b7 30.Kc5 Rc8+ 31.Kb4 Kd7 32.Rba1 Rcb8 33.Ra7 e6 34.
+Rxb7+ Rxb7 35.Ra5 exd5 36.exd5 Kd6 37.Rxb5 Rc7 38.g3 f5 39.Ra5 Rc8 40.Ra7 
+Kxd5 41.Rd7+ Ke4 42.Rxh7 Kd5 43.Rd7+ Ke6 44.Rd4 Rb8+ 45.Kxc4 Rb2 46.h4 Rb1
+47.Kc5 Rb8 48.Rd6+ 1-0


### PR DESCRIPTION
Now throws an exception of this type.

```
StreamParserException("Invalid PGN, missing closing quote in header");
```

fixes https://github.com/Disservin/chess-library/issues/128