### PR TITLE
fix: remove variable in Board::givesCheck

### DIFF
--- a/include/chess.hpp
+++ b/include/chess.hpp
@@ -3080,26 +3080,21 @@ inline CheckType Board::givesCheck(const Move &m) const {
     const Bitboard toBB = Bitboard::fromSquare(to);
     const PieceType pt  = at(from).type();
 
-    Bitboard fromPiece = 0ull, fromKing = 0ull;
+    Bitboard fromKing = 0ull;
 
     if (pt == PieceType::PAWN) {
-        fromPiece = toBB;
         fromKing  = attacks::pawn(~stm_, ksq);
     } else if (pt == PieceType::KNIGHT) {
-        fromPiece = attacks::knight(from);
         fromKing  = attacks::knight(ksq);
     } else if (pt == PieceType::BISHOP) {
-        fromPiece = attacks::bishop(from, occ());
         fromKing  = attacks::bishop(ksq, occ());
     } else if (pt == PieceType::ROOK) {
-        fromPiece = attacks::rook(from, occ());
         fromKing  = attacks::rook(ksq, occ());
     } else if (pt == PieceType::QUEEN) {
-        fromPiece = attacks::queen(from, occ());
         fromKing  = attacks::queen(ksq, occ());
     }
 
-    if (fromPiece & fromKing & toBB) return CheckType::DIRECT_CHECK;
+    if (fromKing & toBB) return CheckType::DIRECT_CHECK;
 
     // Discovery check
     const Bitboard fromBB = Bitboard::fromSquare(from);

--- a/src/board.hpp
+++ b/src/board.hpp
@@ -1409,26 +1409,21 @@ inline CheckType Board::givesCheck(const Move &m) const {
     const Bitboard toBB = Bitboard::fromSquare(to);
     const PieceType pt  = at(from).type();
 
-    Bitboard fromPiece = 0ull, fromKing = 0ull;
+    Bitboard fromKing = 0ull;
 
     if (pt == PieceType::PAWN) {
-        fromPiece = toBB;
         fromKing  = attacks::pawn(~stm_, ksq);
     } else if (pt == PieceType::KNIGHT) {
-        fromPiece = attacks::knight(from);
         fromKing  = attacks::knight(ksq);
     } else if (pt == PieceType::BISHOP) {
-        fromPiece = attacks::bishop(from, occ());
         fromKing  = attacks::bishop(ksq, occ());
     } else if (pt == PieceType::ROOK) {
-        fromPiece = attacks::rook(from, occ());
         fromKing  = attacks::rook(ksq, occ());
     } else if (pt == PieceType::QUEEN) {
-        fromPiece = attacks::queen(from, occ());
         fromKing  = attacks::queen(ksq, occ());
     }
 
-    if (fromPiece & fromKing & toBB) return CheckType::DIRECT_CHECK;
+    if (fromKing & toBB) return CheckType::DIRECT_CHECK;
 
     // Discovery check
     const Bitboard fromBB = Bitboard::fromSquare(from);


### PR DESCRIPTION
The variable fromPiece has been removed from givesCheck as calulating this is completly unnecessary because it alread contains the to-square of the move.