### PR TITLE
refactor SQUARES_BETWEEN and generateCastleMoves

### DIFF
--- a/src/board.hpp
+++ b/src/board.hpp
@@ -881,6 +881,10 @@ class Board {
         return hash_key ^ ep_hash ^ stm_hash ^ castling_hash;
     }
 
+    [[nodiscard]] Bitboard getCastlingPath(Color c, bool isKingSide) const noexcept {
+        return castling_path[c][isKingSide];
+    }
+
     friend std::ostream &operator<<(std::ostream &os, const Board &board);
 
     /**
@@ -1193,6 +1197,8 @@ class Board {
 
     bool chess960_ = false;
 
+    std::array<std::array<Bitboard, 2>, 2> castling_path = {};
+
    private:
     void removePieceInternal(Piece piece, Square sq) {
         assert(board_[sq.index()] == piece && piece != Piece::NONE);
@@ -1377,6 +1383,23 @@ class Board {
 
         assert(key_ == zobrist());
 
+        // init castling_path
+        for (Color c : {Color::WHITE, Color::BLACK}) {
+            const auto king_from = kingSq(c);
+
+            for (const auto side : {CastlingRights::Side::KING_SIDE, CastlingRights::Side::QUEEN_SIDE}) {
+                if (!cr_.has(c, side)) continue;
+
+                const auto rook_from = Square(cr_.getRookFile(c, side), king_from.rank());
+                const auto king_to   = Square::castling_king_square(side == Board::CastlingRights::Side::KING_SIDE, c);
+                const auto rook_to   = Square::castling_rook_square(side == Board::CastlingRights::Side::KING_SIDE, c);
+
+                castling_path[c][side == CastlingRights::Side::KING_SIDE] =
+                    (movegen::between(rook_from, rook_to) | movegen::between(king_from, king_to)) &
+                    ~(Bitboard::fromSquare(king_from) | Bitboard::fromSquare(rook_from));
+            }
+        }
+
         return true;
     }
 
@@ -1482,7 +1505,7 @@ inline CheckType Board::givesCheck(const Move &m) const {
 
     while (sniper) {
         Square sq = sniper.pop();
-        return (!(movegen::SQUARES_BETWEEN_BB[ksq.index()][sq.index()] & toBB) || m.typeOf() == Move::CASTLING)
+        return (!(movegen::between(ksq, sq) & toBB) || m.typeOf() == Move::CASTLING)
                    ? CheckType::DISCOVERY_CHECK
                    : CheckType::NO_CHECK;
     }

--- a/src/board.hpp
+++ b/src/board.hpp
@@ -1391,8 +1391,8 @@ class Board {
                 if (!cr_.has(c, side)) continue;
 
                 const auto rook_from = Square(cr_.getRookFile(c, side), king_from.rank());
-                const auto king_to   = Square::castling_king_square(side == Board::CastlingRights::Side::KING_SIDE, c);
-                const auto rook_to   = Square::castling_rook_square(side == Board::CastlingRights::Side::KING_SIDE, c);
+                const auto king_to   = Square::castling_king_square(side == CastlingRights::Side::KING_SIDE, c);
+                const auto rook_to   = Square::castling_rook_square(side == CastlingRights::Side::KING_SIDE, c);
 
                 castling_path[c][side == CastlingRights::Side::KING_SIDE] =
                     (movegen::between(rook_from, rook_to) | movegen::between(king_from, king_to)) &
@@ -1505,9 +1505,8 @@ inline CheckType Board::givesCheck(const Move &m) const {
 
     while (sniper) {
         Square sq = sniper.pop();
-        return (!(movegen::between(ksq, sq) & toBB) || m.typeOf() == Move::CASTLING)
-                   ? CheckType::DISCOVERY_CHECK
-                   : CheckType::NO_CHECK;
+        return (!(movegen::between(ksq, sq) & toBB) || m.typeOf() == Move::CASTLING) ? CheckType::DISCOVERY_CHECK
+                                                                                     : CheckType::NO_CHECK;
     }
 
     switch (m.typeOf()) {

--- a/src/movegen_fwd.hpp
+++ b/src/movegen_fwd.hpp
@@ -73,8 +73,8 @@ class movegen {
 
     [[nodiscard]] static Bitboard generateKingMoves(Square sq, Bitboard seen, Bitboard movable_square);
 
-    template <Color::underlying c, MoveGenType mt>
-    [[nodiscard]] static Bitboard generateCastleMoves(const Board &board, Square sq, Bitboard seen, Bitboard pinHV);
+    template <Color::underlying c>
+    [[nodiscard]] static Bitboard generateCastleMoves(const Board &board, Square sq, Bitboard seen, Bitboard pinHV) noexcept;
 
     template <typename T>
     static void whileBitboardAdd(Movelist &movelist, Bitboard mask, T func);
@@ -84,6 +84,8 @@ class movegen {
 
     template <Color::underlying c>
     static bool isEpSquareValid(const Board &board, Square ep);
+
+    [[nodiscard]] static Bitboard between(Square sq1, Square sq2) noexcept;
 
     friend class Board;
 };


### PR DESCRIPTION
All functions require to add the end square when using SQUARES_BETWEEN. This commit adds the end square, like SF is doing it.

Along with this I refactored the generateCastleMoves function to a more simplified and readable version.