### PR TITLE
fix: missing-braces warning in array initialization

### DIFF
--- a/src/attacks.hpp
+++ b/src/attacks.hpp
@@ -93,7 +93,7 @@ template <PieceType::underlying pt>
 
 template <bool ISROOK>
 [[nodiscard]] inline Bitboard attacks::sliderAttacks(Square sq, Bitboard occupied) noexcept {
-    static constexpr int dirs[2][4][2] = {{1, 1, 1, -1, -1, -1, -1, 1}, {1, 0, 0, -1, -1, 0, 0, 1}};
+    static constexpr int dirs[2][4][2] = {{{1, 1}, {1, -1}, {-1, -1}, {-1, 1}}, {{1, 0}, {0, -1}, {-1, 0}, {0, 1}}};
 
     Bitboard attacks = 0ull;
 


### PR DESCRIPTION
When updating the `chess.hpp` file to its latest version in my chess engine and compiling, I encountered the following warning:

```
src/chess.hpp:3337:50: warning: suggest braces around initialization of subobject [-Wmissing-braces]
 3337       static constexpr int dirs[2][4][2] = {{1, 1, 1, -1, -1, -1, -1, 1}, {1, 0, 0, -1, -1, 0, 0, 1}};
```

 