### PR TITLE
docs: clarify attackers function description to ensure consistency

### DIFF
--- a/docs/pages/attacks.md
+++ b/docs/pages/attacks.md
@@ -20,7 +20,7 @@ namespace attacks {
     template <Color c>
     Bitboard pawnRightAttacks(const Bitboard pawns);
 
-    /// @brief Returns a bitboard with the origin squares of the attacking pieces set
+    /// @brief Returns the origin squares of pieces of a given color attacking a target square
     /// @param board
     /// @param color Attacker Color
     /// @param square Attacked Square

--- a/src/attacks_fwd.hpp
+++ b/src/attacks_fwd.hpp
@@ -240,10 +240,10 @@ class attacks {
     [[nodiscard]] static Bitboard king(Square sq) noexcept;
 
     /**
-     * @brief Returns the attacks for a given piece on a given square
+     * @brief Returns the origin squares of pieces of a given color attacking a target square
      * @param board
-     * @param color
-     * @param square
+     * @param color Attacker Color
+     * @param square Attacked Square
      * @return
      */
     [[nodiscard]] static Bitboard attackers(const Board &board, Color color, Square square) noexcept;


### PR DESCRIPTION
1. The documentation was inconsistent between the markdown file and the header file.
2. In the header file, the documentation was misleading :
`* @brief Returns the attacks for a given piece on a given square`
while the function does not take a piece as an argument