### PR TITLE
feat: add support for negative move scores

### DIFF
--- a/include/chess.hpp
+++ b/include/chess.hpp
@@ -1272,10 +1272,10 @@ class Move {
      * @brief Set the score for a move. Useful if you later want to sort the moves.
      * @param score
      */
-    constexpr void setScore(std::int16_t score) noexcept { score_ = score; }
+    constexpr void setScore(std::int32_t score) noexcept { score_ = score; }
 
     [[nodiscard]] constexpr std::uint16_t move() const noexcept { return move_; }
-    [[nodiscard]] constexpr std::int16_t score() const noexcept { return score_; }
+    [[nodiscard]] constexpr std::int32_t score() const noexcept { return score_; }
 
     constexpr bool operator==(const Move& rhs) const noexcept { return move_ == rhs.move_; }
     constexpr bool operator!=(const Move& rhs) const noexcept { return move_ != rhs.move_; }
@@ -1289,7 +1289,7 @@ class Move {
 
    private:
     std::uint16_t move_;
-    std::int16_t score_;
+    std::int32_t score_;
 };
 
 }  // namespace chess

--- a/src/move.hpp
+++ b/src/move.hpp
@@ -61,10 +61,10 @@ class Move {
      * @brief Set the score for a move. Useful if you later want to sort the moves.
      * @param score
      */
-    constexpr void setScore(std::int16_t score) noexcept { score_ = score; }
+    constexpr void setScore(std::int32_t score) noexcept { score_ = score; }
 
     [[nodiscard]] constexpr std::uint16_t move() const noexcept { return move_; }
-    [[nodiscard]] constexpr std::int16_t score() const noexcept { return score_; }
+    [[nodiscard]] constexpr std::int32_t score() const noexcept { return score_; }
 
     constexpr bool operator==(const Move& rhs) const noexcept { return move_ == rhs.move_; }
     constexpr bool operator!=(const Move& rhs) const noexcept { return move_ != rhs.move_; }
@@ -78,7 +78,7 @@ class Move {
 
    private:
     std::uint16_t move_;
-    std::int16_t score_;
+    std::int32_t score_;
 };
 
 }  // namespace chess


### PR DESCRIPTION
### Problem
Move::score_ is uint16_t, which prevents storing negative scores. This restricts how engine developers can use the library, as move ordering techniques may require negative scores for bad captures (e.g. captures when SEE < 0).

When a negative score is assigned via setScore(), it silently wraps to a large positive value (~65000), causing bad captures to be 
searched first instead of last.

### Change
Changed Move::score_ from uint16_t to int32_t to support negative scores.

int32_t includes the full uint16_t positive range (0-65535) so existing projects are unaffected.