### PR TITLE
Board::backtrackTo()

### DIFF
--- a/include/chess.hpp
+++ b/include/chess.hpp
@@ -1871,6 +1871,11 @@ class Board {
               enpassant(enpassant),
               half_moves(half_moves),
               captured_piece(captured_piece) {}
+
+        bool operator==(const State& other) const noexcept {
+            return hash == other.hash && castling == other.castling && enpassant == other.enpassant &&
+                   half_moves == other.half_moves && captured_piece == other.captured_piece;
+        }
     };
 
    protected:
@@ -2278,6 +2283,31 @@ class Board {
         stm_ = ~stm_;
 
         prev_states_.pop_back();
+    }
+
+    /**
+     * @brief Backtrack the board state to a previous state. Assumes that the current state was
+     * reached from the previous state by making legal moves. Otherwise the behavior is undefined.
+     * Equivalent to calling unmakeMove() for every move made since the previous state, but faster.
+     * This can be useful in tree-searching algorithms that repeatedly backtrack from leaf nodes to
+     * the root node, like MCTS.
+     * @param previous
+     */
+    void backtrackTo(const Board& previous) {
+        size_t n = previous.prev_states_.size();
+        this->prev_states_.erase(this->prev_states_.begin() + n, this->prev_states_.end());
+
+        this->pieces_bb_    = previous.pieces_bb_;
+        this->occ_bb_       = previous.occ_bb_;
+        this->board_        = previous.board_;
+        this->key_          = previous.key_;
+        this->cr_           = previous.cr_;
+        this->plies_        = previous.plies_;
+        this->stm_          = previous.stm_;
+        this->ep_sq_        = previous.ep_sq_;
+        this->hfm_          = previous.hfm_;
+        this->chess960_     = previous.chess960_;
+        this->castling_path = previous.castling_path;
     }
 
     /**
@@ -3033,6 +3063,14 @@ class Board {
                && chess960_ == other.chess960_  //
                && castling_path == other.castling_path;
     }
+
+    /**
+     * @brief A more comprehensive equality check than operator==. This also checks that the state
+     * history is the same, which is relevant for repetition detection and the 50-move rule. This
+     * typically should not be used in a chess engine, but can be useful for testing and debugging.
+     * @param other
+     */
+    bool fullyEquals(const Board& other) const noexcept { return prev_states_ == other.prev_states_ && *this == other; }
 
    protected:
     virtual void placePiece(Piece piece, Square sq) { placePieceInternal(piece, sq); }

--- a/include/chess.hpp
+++ b/include/chess.hpp
@@ -2294,7 +2294,10 @@ class Board {
      * @param previous
      */
     void backtrackTo(const Board& previous) {
-        size_t n = previous.prev_states_.size();
+        const size_t n = previous.prev_states_.size();
+
+        assert(n <= this->prev_states_.size());
+
         this->prev_states_.erase(this->prev_states_.begin() + n, this->prev_states_.end());
 
         this->pieces_bb_    = previous.pieces_bb_;

--- a/src/board.hpp
+++ b/src/board.hpp
@@ -145,6 +145,11 @@ class Board {
               enpassant(enpassant),
               half_moves(half_moves),
               captured_piece(captured_piece) {}
+
+        bool operator==(const State& other) const noexcept {
+            return hash == other.hash && castling == other.castling && enpassant == other.enpassant &&
+                   half_moves == other.half_moves && captured_piece == other.captured_piece;
+        }
     };
 
    protected:
@@ -552,6 +557,31 @@ class Board {
         stm_ = ~stm_;
 
         prev_states_.pop_back();
+    }
+
+    /**
+     * @brief Backtrack the board state to a previous state. Assumes that the current state was
+     * reached from the previous state by making legal moves. Otherwise the behavior is undefined.
+     * Equivalent to calling unmakeMove() for every move made since the previous state, but faster.
+     * This can be useful in tree-searching algorithms that repeatedly backtrack from leaf nodes to
+     * the root node, like MCTS.
+     * @param previous
+     */
+    void backtrackTo(const Board& previous) {
+        size_t n = previous.prev_states_.size();
+        this->prev_states_.erase(this->prev_states_.begin() + n, this->prev_states_.end());
+
+        this->pieces_bb_    = previous.pieces_bb_;
+        this->occ_bb_       = previous.occ_bb_;
+        this->board_        = previous.board_;
+        this->key_          = previous.key_;
+        this->cr_           = previous.cr_;
+        this->plies_        = previous.plies_;
+        this->stm_          = previous.stm_;
+        this->ep_sq_        = previous.ep_sq_;
+        this->hfm_          = previous.hfm_;
+        this->chess960_     = previous.chess960_;
+        this->castling_path = previous.castling_path;
     }
 
     /**
@@ -1307,6 +1337,14 @@ class Board {
                && chess960_ == other.chess960_  //
                && castling_path == other.castling_path;
     }
+
+    /**
+     * @brief A more comprehensive equality check than operator==. This also checks that the state
+     * history is the same, which is relevant for repetition detection and the 50-move rule. This
+     * typically should not be used in a chess engine, but can be useful for testing and debugging.
+     * @param other
+     */
+    bool fullyEquals(const Board& other) const noexcept { return prev_states_ == other.prev_states_ && *this == other; }
 
    protected:
     virtual void placePiece(Piece piece, Square sq) { placePieceInternal(piece, sq); }

--- a/src/board.hpp
+++ b/src/board.hpp
@@ -568,7 +568,10 @@ class Board {
      * @param previous
      */
     void backtrackTo(const Board& previous) {
-        size_t n = previous.prev_states_.size();
+        const size_t n = previous.prev_states_.size();
+
+        assert(n <= this->prev_states_.size());
+
         this->prev_states_.erase(this->prev_states_.begin() + n, this->prev_states_.end());
 
         this->pieces_bb_    = previous.pieces_bb_;

--- a/tests/board.cpp
+++ b/tests/board.cpp
@@ -130,6 +130,54 @@ TEST_SUITE("Board") {
         }
     }
 
+    TEST_CASE("Board backtrackTo") {
+        SUBCASE("backtrack to root") {
+            Board root;
+            Board board = root;
+
+            board.makeMove(Move::make(Square::SQ_E2, Square::SQ_E4));
+            board.makeMove(Move::make(Square::SQ_E7, Square::SQ_E5));
+            board.makeMove(Move::make(Square::SQ_G1, Square::SQ_F3));
+
+            board.backtrackTo(root);
+            CHECK(board.fullyEquals(root));
+        }
+
+        SUBCASE("backtrack to intermediate node") {
+            Board root;
+            Board board = root;
+
+            board.makeMove(Move::make(Square::SQ_E2, Square::SQ_E4));
+            board.makeMove(Move::make(Square::SQ_E7, Square::SQ_E5));
+            Board intermediate = board;
+
+            board.makeMove(Move::make(Square::SQ_G1, Square::SQ_F3));
+            board.makeMove(Move::make(Square::SQ_B8, Square::SQ_C6));
+
+            board.backtrackTo(intermediate);
+            CHECK(board.fullyEquals(intermediate));
+        }
+
+        SUBCASE("prev_states_ correct after backtrack and re-advance") {
+            Board root;
+            Board board = root;
+
+            board.makeMove(Move::make(Square::SQ_E2, Square::SQ_E4));
+            board.makeMove(Move::make(Square::SQ_E7, Square::SQ_E5));
+            board.backtrackTo(root);
+
+            board.makeMove(Move::make(Square::SQ_D2, Square::SQ_D4));
+            board.makeMove(Move::make(Square::SQ_D7, Square::SQ_D5));
+
+            // Reference: fresh board with only the second line
+            Board reference;
+            reference.makeMove(Move::make(Square::SQ_D2, Square::SQ_D4));
+            reference.makeMove(Move::make(Square::SQ_D7, Square::SQ_D5));
+
+            CHECK(board.fullyEquals(reference));
+        }
+    }
+
     TEST_CASE("Board ") {
         SUBCASE("hasNonPawnMaterial") {
             Board board = Board("4k1n1/pppppppp/8/8/8/8/PPPPPPPP/4K3 w - - 0 1");


### PR DESCRIPTION
This PR adds a `Board` method that facilitates efficient backtracking to a prior state arbitrarily far back in the game history. Such a capability is useful in tree-searching algorithms like MCTS that repeatedly backtrack from leaf nodes to the root node.

Some notes:

- In order to properly test this method, I need to verify that two `Board` instances have matching `prev_states_` members. I did not see public methods that would facilitate such a check. So I added `Board::fullyEquals()`, which in turn motivated the addition of `Board::State::operator==`.

- If the caller ever passes a `Board` argument that violates the requirement that `this` was reached from the argument, what should the behavior be? I chose to declare this to be Undefined Behavior, which I think is the only reasonable choice. Nevertheless, should the method do a cheap check to _partially_ validate the requirement? It could simply validate `size >= prev_size`, and then validate that the last hash matches. If validation fails, it could either fall back to an expensive vector copy or raise an exception. I did not do any validation, but happy to add it if doing so aligns with the philosophy of the library.

- If the project ever upgrades from c++17 to c++20, we can use a compiler-generated default for `operator==`. This would make the the various existing `operator==` definitions more future-proof, although I'm not sure if the addition of new data members to the various structs is a realistic possibility. For `Board`, because `prev_states_` is intentionally not checked by `operator==`, it would be cleaner to move all the other members into an inner struct, with `Board::operator==` dispatching to the struct's `operator==`.