### PR TITLE
efficient Movelist copy-constructor/assignment-operator

### DIFF
--- a/include/chess.hpp
+++ b/include/chess.hpp
@@ -1297,6 +1297,7 @@ class Move {
 
 
 #include <cstddef>
+#include <cstring>
 #include <iterator>
 #include <stdexcept>
 
@@ -1323,17 +1324,28 @@ class Movelist {
 
     Movelist(const Movelist& other) {
         size_ = other.size_;
-        for (size_type i = 0; i < size_; ++i) {
-            moves_[i] = other.moves_[i];
-        }
+        std::memcpy(moves_.data(), other.moves_.data(), size_ * sizeof(Move));
     }
 
     Movelist& operator=(const Movelist& other) {
         if (this != &other) {
             size_ = other.size_;
-            for (size_type i = 0; i < size_; ++i) {
-                moves_[i] = other.moves_[i];
-            }
+            std::memcpy(moves_.data(), other.moves_.data(), size_ * sizeof(Move));
+        }
+        return *this;
+    }
+
+    Movelist(Movelist&& other) noexcept {
+        size_ = other.size_;
+        std::memcpy(moves_.data(), other.moves_.data(), size_ * sizeof(Move));
+        other.size_ = 0;
+    }
+
+    Movelist& operator=(Movelist&& other) noexcept {
+        if (this != &other) {
+            size_ = other.size_;
+            std::memcpy(moves_.data(), other.moves_.data(), size_ * sizeof(Move));
+            other.size_ = 0;
         }
         return *this;
     }

--- a/include/chess.hpp
+++ b/include/chess.hpp
@@ -1318,6 +1318,26 @@ class Movelist {
     using reverse_iterator       = std::reverse_iterator<iterator>;
     using const_reverse_iterator = std::reverse_iterator<const_iterator>;
 
+    // constructors and assignment operator
+    Movelist() = default;
+
+    Movelist(const Movelist& other) {
+        size_ = other.size_;
+        for (size_type i = 0; i < size_; ++i) {
+            moves_[i] = other.moves_[i];
+        }
+    }
+
+    Movelist& operator=(const Movelist& other) {
+        if (this != &other) {
+            size_ = other.size_;
+            for (size_type i = 0; i < size_; ++i) {
+                moves_[i] = other.moves_[i];
+            }
+        }
+        return *this;
+    }
+
     // Element access
 
     [[nodiscard]] constexpr reference at(size_type pos) {

--- a/src/movelist.hpp
+++ b/src/movelist.hpp
@@ -3,6 +3,7 @@
 #include <array>
 #include <cassert>
 #include <cstddef>
+#include <cstring>
 #include <iterator>
 #include <stdexcept>
 #include <string>
@@ -32,17 +33,28 @@ class Movelist {
 
     Movelist(const Movelist& other) {
         size_ = other.size_;
-        for (size_type i = 0; i < size_; ++i) {
-            moves_[i] = other.moves_[i];
-        }
+        std::memcpy(moves_.data(), other.moves_.data(), size_ * sizeof(Move));
     }
 
     Movelist& operator=(const Movelist& other) {
         if (this != &other) {
             size_ = other.size_;
-            for (size_type i = 0; i < size_; ++i) {
-                moves_[i] = other.moves_[i];
-            }
+            std::memcpy(moves_.data(), other.moves_.data(), size_ * sizeof(Move));
+        }
+        return *this;
+    }
+
+    Movelist(Movelist&& other) noexcept {
+        size_ = other.size_;
+        std::memcpy(moves_.data(), other.moves_.data(), size_ * sizeof(Move));
+        other.size_ = 0;
+    }
+
+    Movelist& operator=(Movelist&& other) noexcept {
+        if (this != &other) {
+            size_ = other.size_;
+            std::memcpy(moves_.data(), other.moves_.data(), size_ * sizeof(Move));
+            other.size_ = 0;
         }
         return *this;
     }

--- a/src/movelist.hpp
+++ b/src/movelist.hpp
@@ -27,6 +27,26 @@ class Movelist {
     using reverse_iterator       = std::reverse_iterator<iterator>;
     using const_reverse_iterator = std::reverse_iterator<const_iterator>;
 
+    // constructors and assignment operator
+    Movelist() = default;
+
+    Movelist(const Movelist& other) {
+        size_ = other.size_;
+        for (size_type i = 0; i < size_; ++i) {
+            moves_[i] = other.moves_[i];
+        }
+    }
+
+    Movelist& operator=(const Movelist& other) {
+        if (this != &other) {
+            size_ = other.size_;
+            for (size_type i = 0; i < size_; ++i) {
+                moves_[i] = other.moves_[i];
+            }
+        }
+        return *this;
+    }
+
     // Element access
 
     [[nodiscard]] constexpr reference at(size_type pos) {


### PR DESCRIPTION
This PR adds an efficient copy-constructor and assignment-operator for `chess::Movelist`, for applications that want to copy `chess::Movelist` object instances for whatever reason.